### PR TITLE
Optional repository for RHEL / enabling using subsman

### DIFF
--- a/ansible/tasks/_prep-repos-RedHat.yml
+++ b/ansible/tasks/_prep-repos-RedHat.yml
@@ -23,6 +23,13 @@
       - prereq_enable_repository
       - prereq_enable_repository_rhel_base
 
+ - name: Enable Optional Repository on RHEL7
+    command: subscription-manager repos --enable rhel-7-server-optional-rpms
+    when: ansible_distribution == "RedHat" and ansible_distribution_major_version == "7"
+    tags:
+      - prereq_enable_repository
+      - prereq_enable_repository_rhel_base
+
   - name: Update Red Hat system to the latest version
     yum:
       name: "*"


### PR DESCRIPTION
Optional repository for RHEL / enabling using subsman

Used to enable the optional repo on RHEL7 OS, next, will test/prepare to the CentOS 7 servers.